### PR TITLE
Adiciona rota /me e ajusta claims do JWT

### DIFF
--- a/src/Desbravadores.Gestao.Api/Controllers/AuthController.cs
+++ b/src/Desbravadores.Gestao.Api/Controllers/AuthController.cs
@@ -1,10 +1,11 @@
 ﻿using Desbravadores.Gestao.Application.Auth.Login;
+using Desbravadores.Gestao.Application.Interfaces;
 using Desbravadores.Gestao.Domain.Interfaces.Repositories;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.JsonWebTokens;
-using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 
 namespace Desbravadores.Gestao.Api.Controllers;
 
@@ -52,5 +53,23 @@ public class AuthController(IValidator<LoginRequest> validator) : ControllerBase
     await usuarioSessaoRepository.SaveChangesAsync(cancellationToken);
 
     return NoContent();
+  }
+  [Authorize]
+  [HttpGet("me")]
+  public async Task<IActionResult> Me(
+  [FromServices] IUsuarioRepository usuarioRepository,
+  CancellationToken cancellationToken)
+  {
+    var uuidValue = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+    if (!Guid.TryParse(uuidValue, out var uuid))
+      return Unauthorized("Token inválido: UUID não encontrado.");
+
+    var usuario = await usuarioRepository.GetByUuidAsync(uuid, cancellationToken);
+
+    if (usuario is null)
+      return NotFound("Usuário não encontrado.");
+
+    return Ok(usuario);
   }
 }

--- a/src/Desbravadores.Gestao.Application/Interfaces/IUsuarioRepository.cs
+++ b/src/Desbravadores.Gestao.Application/Interfaces/IUsuarioRepository.cs
@@ -7,6 +7,7 @@ public interface IUsuarioRepository
 {
     Task<Usuario?> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
     Task<UsuarioDTO?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Usuario?> GetByUuidAsync(Guid uuid, CancellationToken cancellationToken = default);
     Task AdicionarUsuarioAsync(Usuario usuario, CancellationToken cancellationToken = default);
     Task<IEnumerable<UsuarioDTO>> GetAllAsync(CancellationToken cancellationToken = default);
     Task RemoveAsync(Usuario usuario, CancellationToken cancellationToken = default);

--- a/src/Desbravadores.Gestao.Infrastructure/Repositories/UsuarioRepository.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/Repositories/UsuarioRepository.cs
@@ -45,6 +45,13 @@ public sealed class UsuarioRepository(AppDbContext context) : IUsuarioRepository
             DataCriacao = u.DataCriacao
         })
         .FirstOrDefaultAsync(cancellationToken);
+
+  public async Task<Usuario?> GetByUuidAsync(Guid uuid, CancellationToken cancellationToken = default)
+  {
+    return await _context
+        .Usuarios
+        .FirstOrDefaultAsync(x => x.Uuid == uuid, cancellationToken);
+  }
   public async Task RemoveAsync(Usuario usuario, CancellationToken cancellationToken = default)
   {
       await _context.Usuarios.Where(u => u.Uuid == usuario.Uuid).ExecuteDeleteAsync(cancellationToken);

--- a/src/Desbravadores.Gestao.Infrastructure/Security/TokenService.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/Security/TokenService.cs
@@ -32,16 +32,16 @@ public sealed class TokenService : ITokenService
       var refreshTokenExpires = DateTime.UtcNow.AddDays(refreshTokenDays);
 
       var claims = new List<Claim>
-    {
-      new(JwtRegisteredClaimNames.Sub, usuario.Id.ToString()),
-      new(JwtRegisteredClaimNames.Email, usuario.Email),
-      new(JwtRegisteredClaimNames.Jti, jti),
-      new("uid", usuario.Uuid.ToString()),
-      new(ClaimTypes.Name, usuario.Nome),
-      new(ClaimTypes.Role, usuario.Role)
-    };
+      {
+        new(JwtRegisteredClaimNames.Sub, usuario.Uuid.ToString()),
+        new(JwtRegisteredClaimNames.Email, usuario.Email),
+        new(JwtRegisteredClaimNames.Jti, jti),
+        new("user_id", usuario.Id.ToString()),
+        new(ClaimTypes.Name, usuario.Nome),
+        new(ClaimTypes.Role, usuario.Role)
+      };
 
-      var token = new JwtSecurityToken(
+    var token = new JwtSecurityToken(
           issuer: issuer,
           audience: audience,
           claims: claims,


### PR DESCRIPTION
Adicionada a rota GET /api/auth/me para retornar dados do usuário autenticado via UUID do token. Incluído método GetByUuidAsync no repositório de usuários. Alterado o claim "sub" do JWT para usar o UUID e criado claim customizado "user_id" para o ID; claim "uid" removido.