### PR TITLE
Revoga sessões ativas do usuário ao realizar login

### DIFF
--- a/src/Desbravadores.Gestao.Application/Auth/Login/LoginRequestHandler.cs
+++ b/src/Desbravadores.Gestao.Application/Auth/Login/LoginRequestHandler.cs
@@ -25,6 +25,8 @@ public sealed class LoginRequestHandler(
 
     if (!senhaValida)
       throw new UnauthorizedAccessException("E-mail ou senha inválidos.");
+    
+    await _usuarioSessaoRepository.RevokeAllActiveByUsuarioIdAsync(usuario.Id, cancellationToken);
 
     TokenResult token = await _tokenService.GenerateToken(usuario);
 

--- a/src/Desbravadores.Gestao.Domain/Interfaces/Repositories/IUsuarioSessaoRepository.cs
+++ b/src/Desbravadores.Gestao.Domain/Interfaces/Repositories/IUsuarioSessaoRepository.cs
@@ -7,5 +7,6 @@ public interface IUsuarioSessaoRepository
   Task AddAsync(UsuarioSessao sessao, CancellationToken cancellationToken = default);
   Task<UsuarioSessao?> GetByJtiAsync(string jti, CancellationToken cancellationToken = default);
   Task<UsuarioSessao?> GetByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+  Task RevokeAllActiveByUsuarioIdAsync(long usuarioId, CancellationToken cancellationToken = default);
   Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Desbravadores.Gestao.Infrastructure/Repositories/UsuarioSessaoRepository.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/Repositories/UsuarioSessaoRepository.cs
@@ -26,6 +26,20 @@ public sealed class UsuarioSessaoRepository(AppDbContext context) : IUsuarioSess
         .Include(x => x.Usuario)
         .FirstOrDefaultAsync(x => x.RefreshToken == refreshToken, cancellationToken);
   }
+   public async Task RevokeAllActiveByUsuarioIdAsync(long usuarioId, CancellationToken cancellationToken = default)
+  {
+    var agora = DateTime.UtcNow;
+
+    var sessoesAtivas = await _context.UsuarioSessoes
+      .Where(x =>
+          x.UsuarioId == usuarioId &&
+          !x.Revogado &&
+          x.RefreshTokenExpiraEm > agora)
+      .ToListAsync(cancellationToken);
+
+    foreach (var sessao in sessoesAtivas)
+      sessao.Revogar();
+  }
 
   public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
   {


### PR DESCRIPTION
Adiciona método RevokeAllActiveByUsuarioIdAsync no repositório e interface de sessões de usuário. Garante que, ao efetuar login, todas as sessões anteriores do usuário sejam revogadas, mantendo apenas a nova sessão ativa.