### PR TITLE
Removendo autorizacao token

### DIFF
--- a/src/Desbravadores.Gestao.Api/Controllers/AuthController.cs
+++ b/src/Desbravadores.Gestao.Api/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 ﻿using Desbravadores.Gestao.Application.Auth.Login;
-using Desbravadores.Gestao.Application.Interfaces;
-using Desbravadores.Gestao.Domain.Interfaces.Repositories;
+using Desbravadores.Gestao.Application.Auth.Logout;
+using Desbravadores.Gestao.Application.Auth.Me;
+using Desbravadores.Gestao.Domain.DTOs;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -37,59 +38,34 @@ public class AuthController(IValidator<LoginRequest> validator) : ControllerBase
   [ProducesResponseType(StatusCodes.Status204NoContent)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   public async Task<IActionResult> Logout(
-    [FromServices] IUsuarioSessaoRepository usuarioSessaoRepository,
+    [FromServices] LogoutRequestHandler logoutRequestHandler,
     CancellationToken cancellationToken)
   {
-    var jti = User.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
-
-    if (string.IsNullOrWhiteSpace(jti))
-      return Unauthorized();
-
-    var sessao = await usuarioSessaoRepository.GetByJtiAsync(jti, cancellationToken);
-
-    if (sessao is null)
-      return Unauthorized();
-
-    sessao.Revogar();
-    await usuarioSessaoRepository.SaveChangesAsync(cancellationToken);
+    await logoutRequestHandler.HandleAsync(
+        User.FindFirst(JwtRegisteredClaimNames.Jti)?.Value ?? string.Empty,
+        cancellationToken);
 
     return NoContent();
   }
 
-
   [Authorize]
   [HttpGet("Me")]
-  [ProducesResponseType(StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(UsuarioDTO), StatusCodes.Status200OK)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   [ProducesResponseType(StatusCodes.Status404NotFound)]
   public async Task<IActionResult> Me(
-      [FromServices] IUsuarioRepository usuarioRepository,
-      [FromServices] IUsuarioSessaoRepository usuarioSessaoRepository,
-      CancellationToken cancellationToken)
+    [FromServices] MeRequestHandler meRequestHandler,
+    CancellationToken cancellationToken)
   {
-    var uuidValue = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
-        ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
-
-    if (!Guid.TryParse(uuidValue, out var uuid))
-      return Unauthorized("Token inválido: UUID não encontrado.");
+    var sub = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+              ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
 
     var jti = User.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
 
-    if (string.IsNullOrWhiteSpace(jti))
-      return Unauthorized("Token inválido: JTI não encontrado.");
+    if (string.IsNullOrWhiteSpace(sub) || string.IsNullOrWhiteSpace(jti))
+      return Unauthorized("Token inválido.");
 
-    var usuario = await usuarioRepository.GetByUuidAsync(uuid, cancellationToken);
-
-    if (usuario is null)
-      return NotFound("Usuário não encontrado.");
-
-    var tokenValido = await usuarioSessaoRepository.ExistsActiveSessionAsync(
-        usuario.Id,
-        jti,
-        cancellationToken);
-
-    if (!tokenValido)
-      return Unauthorized("Token revogado, expirado ou inválido.");
+    var usuario = await meRequestHandler.HandleAsync(sub, jti, cancellationToken);
 
     return Ok(usuario);
   }

--- a/src/Desbravadores.Gestao.Application/Auth/Login/LoginRequestHandler.cs
+++ b/src/Desbravadores.Gestao.Application/Auth/Login/LoginRequestHandler.cs
@@ -26,6 +26,8 @@ public sealed class LoginRequestHandler(
     if (!senhaValida)
       throw new UnauthorizedAccessException("E-mail ou senha inválidos.");
 
+    await _usuarioSessaoRepository.RevokeAllActiveByUsuarioIdAsync(usuario.Id, cancellationToken);
+
     TokenResult token = await _tokenService.GenerateToken(usuario);
 
     var sessao = new UsuarioSessao(

--- a/src/Desbravadores.Gestao.Application/Auth/Logout/LogoutRequestHandler.cs
+++ b/src/Desbravadores.Gestao.Application/Auth/Logout/LogoutRequestHandler.cs
@@ -1,0 +1,21 @@
+﻿using Desbravadores.Gestao.Domain.Interfaces.Repositories;
+
+namespace Desbravadores.Gestao.Application.Auth.Logout;
+
+public sealed class LogoutRequestHandler(IUsuarioSessaoRepository usuarioSessaoRepository)
+{
+  private readonly IUsuarioSessaoRepository _usuarioSessaoRepository = usuarioSessaoRepository;
+  public async Task HandleAsync(string jti, CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(jti))
+      throw new UnauthorizedAccessException("Token de acesso inválido.");
+
+    var sessao = await usuarioSessaoRepository.GetByJtiAsync(jti, cancellationToken);
+
+    if (sessao is null)
+      throw new UnauthorizedAccessException("Sessão não encontrada.");
+
+    sessao.Revogar();
+    await usuarioSessaoRepository.SaveChangesAsync(cancellationToken);
+  }
+}

--- a/src/Desbravadores.Gestao.Application/Auth/Me/MeRequestHandler.cs
+++ b/src/Desbravadores.Gestao.Application/Auth/Me/MeRequestHandler.cs
@@ -1,0 +1,42 @@
+﻿using Desbravadores.Gestao.Application.Interfaces;
+using Desbravadores.Gestao.Domain.DTOs;
+using Desbravadores.Gestao.Domain.Interfaces.Repositories;
+
+namespace Desbravadores.Gestao.Application.Auth.Me;
+
+public sealed class MeRequestHandler(
+  IUsuarioSessaoRepository usuarioSessaoRepository,
+  IUsuarioRepository usuarioRepository)
+{
+  private readonly IUsuarioSessaoRepository _usuarioSessaoRepository = usuarioSessaoRepository;
+  private readonly IUsuarioRepository _usuarioRepository = usuarioRepository;
+
+  public async Task<UsuarioDTO> HandleAsync(string sub, string jti, CancellationToken cancellationToken = default)
+  {
+    var uuidValue = sub;
+
+    if (!Guid.TryParse(uuidValue, out var uuid))
+      throw new UnauthorizedAccessException("Token inválido: UUID não encontrado.");
+
+    if (string.IsNullOrWhiteSpace(jti))
+      throw new UnauthorizedAccessException("Token inválido: JTI não encontrado.");
+
+    var usuario = await _usuarioRepository.GetByUuidAsync(uuid, cancellationToken) 
+      ?? throw new Exception("Usuário não encontrado.");
+    
+      var tokenValido = await _usuarioSessaoRepository.ExistsActiveSessionAsync(
+        usuario.Id,
+        jti,
+        cancellationToken);
+
+    if (!tokenValido)
+      throw new UnauthorizedAccessException("Token revogado, expirado ou inválido.");
+    
+    return new UsuarioDTO{
+      Id = usuario.Uuid,
+      Nome = usuario.Nome, 
+      Email = usuario.Email, 
+      DataCriacao = usuario.DataCriacao
+    };
+  }
+}

--- a/src/Desbravadores.Gestao.Application/DependencyInjection.cs
+++ b/src/Desbravadores.Gestao.Application/DependencyInjection.cs
@@ -1,4 +1,6 @@
 ﻿using Desbravadores.Gestao.Application.Auth.Login;
+using Desbravadores.Gestao.Application.Auth.Logout;
+using Desbravadores.Gestao.Application.Auth.Me;
 using Desbravadores.Gestao.Application.UseCases.Usuarios.CriarUsuario;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,10 +11,15 @@ public static class DependencyInjection
 {
   public static IServiceCollection AddApplication(this IServiceCollection services)
   {
-    services.AddScoped<CriarUsuarioRequestHandler>();
-    services.AddScoped<LoginRequestHandler>();
-    services.AddScoped<IValidator<LoginRequest>, LoginRequestValidator>();
     services.AddScoped<IValidator<CriarUsuarioRequest>, CriarUsuarioValidation>();
+    services.AddScoped<CriarUsuarioRequestHandler>();
+    
+    services.AddScoped<IValidator<LoginRequest>, LoginRequestValidator>();
+    services.AddScoped<LoginRequestHandler>();
+    
+    services.AddScoped<LogoutRequestHandler>();
+    services.AddScoped<MeRequestHandler>();
+    
     return services;
   }
 }

--- a/src/Desbravadores.Gestao.Application/Desbravadores.Gestao.Application.csproj
+++ b/src/Desbravadores.Gestao.Application/Desbravadores.Gestao.Application.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
🚀 Principais alterações
Implementado mecanismo de revogação de tokens anteriores no login
Criação de controle de sessão via entidade UsuarioSessao
Validação de token baseada no JTI (JWT ID) armazenado em banco
Implementação do fluxo de logout com revogação da sessão ativa
Criação do MeRequestHandler com validação de:
sub (UUID do usuário)
jti (identificador único do token)
sessão ativa e não revogada
Separação de responsabilidades entre:
UsuarioRepository
UsuarioSessaoRepository