### PR TITLE
Adicionar proxy reverso Nginx ao ambiente Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,19 @@ services:
       JWT_AUDIENCE: "Desbravadores.Gestao.Web"
       Jwt_ExpiresInMinutes: "120"
       Jwt_RefreshTokenDays: "7"
-      ConnectionStrings__DefaultConnection: "Server=sqlserver,1433;Database=DesbravadoresDb;User Id=sa;Password=Bkur6etc@10;TrustServerCertificate=True;" 
+      ConnectionStrings__DefaultConnection: "Server=sqlserver,1433;Database=DesbravadoresDb;User Id=sa;Password=Bkur6etc@10;TrustServerCertificate=True;"
+    expose:
+      - "10000"
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: desbravadores_nginx
+    depends_on:
+      - api
     ports:
-      - "8080:10000"
+      - "8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
 
 volumes:
   sql_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,20 @@
+events {}
+
+http {
+    upstream desbravadores_api {
+        server api:10000;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://desbravadores_api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Encaminhar todo o tráfego externo através de um proxy reverso Nginx em vez de expor diretamente a porta da API ao host.
- Permitir centralizar headers `X-Forwarded-*` e facilitar futura configuração de TLS ou múltiplos serviços atrás do proxy.

### Description
- Adicionado `nginx/nginx.conf` com um `upstream desbravadores_api` apontando para `api:10000` e com as diretivas de proxy e headers (`Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`).
- Adicionado serviço `nginx` em `docker-compose.yml` usando a imagem `nginx:1.27-alpine`, com volume `./nginx/nginx.conf:/etc/nginx/nginx.conf:ro`, dependência `api` e mapeamento de porta `8080:80`.
- Ajustado serviço `api` em `docker-compose.yml` para usar `expose: "10000"` (comunicação interna) em vez de publicar a porta diretamente no host.
- Nenhuma alteração foi feita no `Dockerfile` ou no código da aplicação.

### Testing
- Executado `dotnet test` no ambiente de execução disponível, que falhou com `dotnet: command not found` devido à ausência do SDK no ambiente.
- Executado `docker compose build` no ambiente de execução disponível, que falhou com `docker: command not found` devido à ausência do Docker no ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff4442864832e8792c1792ada5881)