### PR TITLE
feat(swagger): aplicar tema escuro automático no Swagger UI

### DIFF
--- a/src/Desbravadores.Gestao.Api/Program.cs
+++ b/src/Desbravadores.Gestao.Api/Program.cs
@@ -129,8 +129,13 @@ using (var scope = app.Services.CreateScope())
     db.Database.EnsureCreated();
 }
 
+app.UseStaticFiles();
+
 app.UseSwagger();
-app.UseSwaggerUI();
+app.UseSwaggerUI(options =>
+{
+  options.InjectJavascript("/swagger-ui/theme-switcher.js");
+});
 
 app.UseHttpsRedirection();
 

--- a/src/Desbravadores.Gestao.Api/wwwroot/swagger-ui/theme-switcher.js
+++ b/src/Desbravadores.Gestao.Api/wwwroot/swagger-ui/theme-switcher.js
@@ -1,0 +1,33 @@
+(function () {
+  const darkThemeId = 'swagger-dark-theme';
+  const darkThemeHref = 'https://cdn.jsdelivr.net/npm/swagger-ui-themes@3.0.1/themes/3.x/theme-monokai.css';
+
+  function applyTheme(isDark) {
+    const existingTheme = document.getElementById(darkThemeId);
+
+    if (isDark) {
+      if (!existingTheme) {
+        const link = document.createElement('link');
+        link.id = darkThemeId;
+        link.rel = 'stylesheet';
+        link.href = darkThemeHref;
+        document.head.appendChild(link);
+      }
+
+      return;
+    }
+
+    if (existingTheme) {
+      existingTheme.remove();
+    }
+  }
+
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  applyTheme(mediaQuery.matches);
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', (event) => applyTheme(event.matches));
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener((event) => applyTheme(event.matches));
+  }
+})();


### PR DESCRIPTION
### Motivation
- Permitir que o Swagger UI siga o tema padrão do sistema operacional e exiba automaticamente um tema escuro quando o SO estiver em modo escuro.

### Description
- Adicionado `src/Desbravadores.Gestao.Api/wwwroot/swagger-ui/theme-switcher.js` que detecta `prefers-color-scheme: dark` e injeta/remova um CSS de tema escuro (`swagger-ui-themes` Monokai) conforme necessário.
- Registrado o arquivo estático com `app.UseStaticFiles()` e configurado `UseSwaggerUI` para injetar o script com `options.InjectJavascript("/swagger-ui/theme-switcher.js")` em `Program.cs`.
- O script reage a mudanças dinâmicas do sistema usando `addEventListener` com fallback para `addListener`.

### Testing
- Executado `dotnet build Desbravadores.Gestao.slnx` no ambiente de execução disponível e falhou com `dotnet: command not found` devido à falta do SDK no runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effdb05384832e86f5dfbfd4fe9900)