### PR TITLE
fix: padroniza AppDbContext para usar PostgreSQL (UseNpgsql) em todos os ambientes

### DIFF
--- a/src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs
@@ -11,21 +11,13 @@ public static class DependencyInjection
 {
   public static IServiceCollection AddInfrastructure(this IServiceCollection services)
   {
-    bool isDevelopment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
-    if(isDevelopment) 
-    {
-      services.AddDbContext<AppDbContext>(options =>
-            options.UseSqlServer(
-              Environment.GetEnvironmentVariable("DefaultConnectionDesbravadores")
-              ?? throw new InvalidOperationException("Connection string 'DefaultConnection' não configurada."))
-            );
-    }else{
-      services.AddDbContext<AppDbContext>(options =>
-          options.UseNpgsql(
-            Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
-            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' não configurada."))
-          );
-    }
+    string connectionString =
+      Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+      ?? Environment.GetEnvironmentVariable("DefaultConnectionDesbravadores")
+      ?? throw new InvalidOperationException("Connection string 'DefaultConnection' não configurada.");
+
+    services.AddDbContext<AppDbContext>(options =>
+      options.UseNpgsql(connectionString));
 
     services.AddScoped<IUsuarioRepository, UsuarioRepository>();
     services.AddScoped<IUsuarioSessaoRepository, UsuarioSessaoRepository>();


### PR DESCRIPTION
### Motivation
- O ambiente está usando PostgreSQL e havia divergência de provider entre `Development` (SQL Server) e demais ambientes, causando falha de login; a intenção é padronizar o provider para evitar incompatibilidades. 

### Description
- Removi a ramificação por ambiente que chamava `UseSqlServer` em `Development` e passei a usar sempre `UseNpgsql` em `src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs`.
- Padronizei a obtenção da connection string para ler `ConnectionStrings__DefaultConnection` e em fallback `DefaultConnectionDesbravadores`, lançando `InvalidOperationException` se ausente.
- Mantive as configurações de repositórios e serviços já registrados; as migrations existentes que ainda referenciam SQL Server não foram alteradas neste PR e devem ser regeneradas/aplicadas em um ambiente com .NET SDK.

### Testing
- Tentei gerar a migration com `dotnet ef migrations add SwitchToPostgresProvider --project src/Desbravadores.Gestao.Infrastructure --startup-project src/Desbravadores.Gestao.Api`, porém o comando falhou com `dotnet: command not found` neste ambiente (sem .NET SDK), portanto a migration não foi criada.
- Não foram executados testes automatizados adicionais neste ambiente após a alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2e689a4c832e88131d8950e1a31c)