### PR TITLE
Implementa logging de entrada, saída e exceções da API

### DIFF
--- a/src/Desbravadores.Gestao.Api/Middlewares/RequestResponseLoggingMiddleware.cs
+++ b/src/Desbravadores.Gestao.Api/Middlewares/RequestResponseLoggingMiddleware.cs
@@ -1,0 +1,175 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Desbravadores.Gestao.Application.Interfaces;
+using Desbravadores.Gestao.Domain.Entities;
+
+namespace Desbravadores.Gestao.Api.Middlewares;
+
+public sealed class RequestResponseLoggingMiddleware(RequestDelegate next)
+{
+  private const int MaxBodyLength = 8000;
+  private static readonly HashSet<string> SensitiveFields =
+  [
+    "password",
+    "senha",
+    "token",
+    "accessToken",
+    "refreshToken",
+    "authorization",
+    "cookie",
+    "set-cookie"
+  ];
+
+  private readonly RequestDelegate _next = next;
+
+  public async Task InvokeAsync(HttpContext context, IApiRequestLogRepository logRepository, IWebHostEnvironment environment)
+  {
+    var stopwatch = Stopwatch.StartNew();
+    var now = DateTime.UtcNow;
+
+    var requestBody = await ReadRequestBodyAsync(context.Request);
+    var requestHeaders = MaskHeaders(context.Request.Headers);
+
+    var originalBody = context.Response.Body;
+    await using var responseBodyStream = new MemoryStream();
+    context.Response.Body = responseBodyStream;
+
+    Exception? capturedException = null;
+
+    try
+    {
+      await _next(context);
+    }
+    catch (Exception ex)
+    {
+      capturedException = ex;
+      throw;
+    }
+    finally
+    {
+      stopwatch.Stop();
+
+      responseBodyStream.Seek(0, SeekOrigin.Begin);
+      var responseBody = await new StreamReader(responseBodyStream).ReadToEndAsync();
+      responseBodyStream.Seek(0, SeekOrigin.Begin);
+      await responseBodyStream.CopyToAsync(originalBody);
+      context.Response.Body = originalBody;
+
+      var apiLog = new ApiRequestLog
+      {
+        DataHora = now,
+        MetodoHttp = context.Request.Method,
+        Endpoint = context.Request.Path.ToString(),
+        QueryString = context.Request.QueryString.Value,
+        RequestHeaders = requestHeaders,
+        RequestBody = MaskContent(requestBody),
+        StatusCode = context.Response.StatusCode,
+        ResponseBody = MaskContent(responseBody),
+        TempoExecucaoMs = stopwatch.ElapsedMilliseconds,
+        UsuarioId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value,
+        UsuarioEmail = context.User.FindFirst(ClaimTypes.Email)?.Value,
+        CorrelationId = GetCorrelationId(context),
+        TraceId = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier,
+        IpOrigem = context.Connection.RemoteIpAddress?.ToString(),
+        Sucesso = capturedException is null && context.Response.StatusCode is >= 200 and < 400,
+        ExceptionType = capturedException?.GetType().FullName,
+        ExceptionMessage = capturedException?.Message,
+        StackTrace = Limit(capturedException?.StackTrace),
+        Ambiente = environment.EnvironmentName
+      };
+
+      try
+      {
+        await logRepository.AddAsync(apiLog, context.RequestAborted);
+      }
+      catch
+      {
+        // Falhas no logging não devem interromper o fluxo principal.
+      }
+    }
+  }
+
+  private static async Task<string?> ReadRequestBodyAsync(HttpRequest request)
+  {
+    if (request.ContentLength is null or 0 || request.Body is null || !request.Body.CanRead)
+      return null;
+
+    request.EnableBuffering();
+    request.Body.Position = 0;
+
+    using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
+    var body = await reader.ReadToEndAsync();
+    request.Body.Position = 0;
+
+    return Limit(body);
+  }
+
+  private static string? GetCorrelationId(HttpContext context)
+  {
+    if (context.Request.Headers.TryGetValue("X-Correlation-Id", out var correlationHeader))
+      return correlationHeader.ToString();
+
+    if (context.Response.Headers.TryGetValue("X-Correlation-Id", out var responseCorrelationHeader))
+      return responseCorrelationHeader.ToString();
+
+    return context.TraceIdentifier;
+  }
+
+  private static string MaskHeaders(IHeaderDictionary headers)
+  {
+    var dictionary = headers.ToDictionary(
+      x => x.Key,
+      x => SensitiveFields.Contains(x.Key, StringComparer.OrdinalIgnoreCase)
+        ? "***"
+        : string.Join(",", x.Value.ToArray())
+    );
+
+    return Serialize(dictionary);
+  }
+
+  private static string? MaskContent(string? content)
+  {
+    if (string.IsNullOrWhiteSpace(content))
+      return content;
+
+    try
+    {
+      using var document = JsonDocument.Parse(content);
+      var masked = MaskElement(document.RootElement);
+      return Serialize(masked);
+    }
+    catch
+    {
+      return Limit(content);
+    }
+  }
+
+  private static object? MaskElement(JsonElement element)
+  {
+    return element.ValueKind switch
+    {
+      JsonValueKind.Object => element
+        .EnumerateObject()
+        .ToDictionary(
+          prop => prop.Name,
+          prop => SensitiveFields.Contains(prop.Name, StringComparer.OrdinalIgnoreCase)
+            ? "***"
+            : MaskElement(prop.Value)
+        ),
+      JsonValueKind.Array => element.EnumerateArray().Select(MaskElement).ToList(),
+      JsonValueKind.String => element.GetString(),
+      JsonValueKind.Number => element.ToString(),
+      JsonValueKind.True => true,
+      JsonValueKind.False => false,
+      _ => null
+    };
+  }
+
+  private static string Serialize(object? value)
+    => JsonSerializer.Serialize(value);
+
+  private static string? Limit(string? value)
+    => value is null ? null : value.Length <= MaxBodyLength ? value : value[..MaxBodyLength];
+}

--- a/src/Desbravadores.Gestao.Api/Program.cs
+++ b/src/Desbravadores.Gestao.Api/Program.cs
@@ -1,3 +1,4 @@
+using Desbravadores.Gestao.Api.Middlewares;
 using Desbravadores.Gestao.Api.Security;
 using Desbravadores.Gestao.Application;
 using Desbravadores.Gestao.Infrastructure;
@@ -137,6 +138,8 @@ var app = builder.Build();
           }
         });
       });
+
+app.UseMiddleware<RequestResponseLoggingMiddleware>();
 
 using (var scope = app.Services.CreateScope())
 {

--- a/src/Desbravadores.Gestao.Application/Interfaces/IApiRequestLogRepository.cs
+++ b/src/Desbravadores.Gestao.Application/Interfaces/IApiRequestLogRepository.cs
@@ -1,0 +1,8 @@
+using Desbravadores.Gestao.Domain.Entities;
+
+namespace Desbravadores.Gestao.Application.Interfaces;
+
+public interface IApiRequestLogRepository
+{
+  Task AddAsync(ApiRequestLog apiRequestLog, CancellationToken cancellationToken = default);
+}

--- a/src/Desbravadores.Gestao.Domain/Entities/ApiRequestLog.cs
+++ b/src/Desbravadores.Gestao.Domain/Entities/ApiRequestLog.cs
@@ -1,0 +1,25 @@
+namespace Desbravadores.Gestao.Domain.Entities;
+
+public sealed class ApiRequestLog
+{
+  public long Id { get; set; }
+  public DateTime DataHora { get; set; }
+  public string MetodoHttp { get; set; } = string.Empty;
+  public string Endpoint { get; set; } = string.Empty;
+  public string? QueryString { get; set; }
+  public string? RequestHeaders { get; set; }
+  public string? RequestBody { get; set; }
+  public int StatusCode { get; set; }
+  public string? ResponseBody { get; set; }
+  public long TempoExecucaoMs { get; set; }
+  public string? UsuarioId { get; set; }
+  public string? UsuarioEmail { get; set; }
+  public string? CorrelationId { get; set; }
+  public string? TraceId { get; set; }
+  public string? IpOrigem { get; set; }
+  public bool Sucesso { get; set; }
+  public string? ExceptionType { get; set; }
+  public string? ExceptionMessage { get; set; }
+  public string? StackTrace { get; set; }
+  public string? Ambiente { get; set; }
+}

--- a/src/Desbravadores.Gestao.Infrastructure/Data/AppDbContext.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/Data/AppDbContext.cs
@@ -7,6 +7,7 @@ namespace Desbravadores.Gestao.Infrastructure.Data
   {
     public DbSet<Usuario> Usuarios => Set<Usuario>();
     public DbSet<UsuarioSessao> UsuarioSessoes => Set<UsuarioSessao>();
+    public DbSet<ApiRequestLog> ApiRequestLogs => Set<ApiRequestLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -61,6 +62,33 @@ namespace Desbravadores.Gestao.Infrastructure.Data
               .WithMany()
               .HasForeignKey(x => x.UsuarioLogadoId)
               .OnDelete(DeleteBehavior.Restrict);
+      });
+
+
+      modelBuilder.Entity<ApiRequestLog>(entity =>
+      {
+        entity.ToTable("ApiRequestLogs");
+
+        entity.HasKey(x => x.Id);
+
+        entity.Property(x => x.DataHora).IsRequired();
+        entity.Property(x => x.MetodoHttp).IsRequired().HasMaxLength(12);
+        entity.Property(x => x.Endpoint).IsRequired().HasMaxLength(500);
+        entity.Property(x => x.StatusCode).IsRequired();
+        entity.Property(x => x.TempoExecucaoMs).IsRequired();
+        entity.Property(x => x.Sucesso).IsRequired();
+        entity.Property(x => x.CorrelationId).HasMaxLength(120);
+        entity.Property(x => x.TraceId).HasMaxLength(120);
+        entity.Property(x => x.IpOrigem).HasMaxLength(45);
+        entity.Property(x => x.UsuarioId).HasMaxLength(120);
+        entity.Property(x => x.UsuarioEmail).HasMaxLength(200);
+        entity.Property(x => x.Ambiente).HasMaxLength(64);
+
+        entity.HasIndex(x => x.DataHora);
+        entity.HasIndex(x => x.Endpoint);
+        entity.HasIndex(x => x.StatusCode);
+        entity.HasIndex(x => x.CorrelationId);
+        entity.HasIndex(x => x.TraceId);
       });
 
       modelBuilder.Entity<UsuarioSessao>(entity =>

--- a/src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs
@@ -21,6 +21,7 @@ public static class DependencyInjection
 
     services.AddScoped<IUsuarioRepository, UsuarioRepository>();
     services.AddScoped<IUsuarioSessaoRepository, UsuarioSessaoRepository>();
+    services.AddScoped<IApiRequestLogRepository, ApiRequestLogRepository>();
     services.AddScoped<ITokenService, TokenService>();
     services.AddScoped<IPasswordHasher, PasswordHasher>();
 

--- a/src/Desbravadores.Gestao.Infrastructure/Repositories/ApiRequestLogRepository.cs
+++ b/src/Desbravadores.Gestao.Infrastructure/Repositories/ApiRequestLogRepository.cs
@@ -1,0 +1,16 @@
+using Desbravadores.Gestao.Application.Interfaces;
+using Desbravadores.Gestao.Domain.Entities;
+using Desbravadores.Gestao.Infrastructure.Data;
+
+namespace Desbravadores.Gestao.Infrastructure.Repositories;
+
+public sealed class ApiRequestLogRepository(AppDbContext context) : IApiRequestLogRepository
+{
+  private readonly AppDbContext _context = context;
+
+  public async Task AddAsync(ApiRequestLog apiRequestLog, CancellationToken cancellationToken = default)
+  {
+    await _context.ApiRequestLogs.AddAsync(apiRequestLog, cancellationToken);
+    await _context.SaveChangesAsync(cancellationToken);
+  }
+}


### PR DESCRIPTION
### Motivation
- Fornecer rastreabilidade e observabilidade internas complementares ao OpenTelemetry, salvando histórico consultável de chamadas HTTP para diagnóstico, auditoria e suporte.
- Garantir registro de entrada, saída, tempo de execução, status e exceções de todas as requisições sem impactar o fluxo principal da aplicação.
- Proteger privacidade e segurança mascarando campos sensíveis e limitando o tamanho dos bodies gravados.

### Description
- Adiciona middleware `RequestResponseLoggingMiddleware` em `src/Desbravadores.Gestao.Api/Middlewares/RequestResponseLoggingMiddleware.cs` que captura request/response, tempo de execução, status code, usuário autenticado, `CorrelationId`/`TraceId`, IP e exceções, e persiste via repositório; o middleware não interrompe a requisição caso o logging falhe.
- Cria entidade de domínio `ApiRequestLog` em `src/Desbravadores.Gestao.Domain/Entities/ApiRequestLog.cs` com campos de entrada, saída, métricas e exceção necessários para rastreabilidade.
- Implementa contrato `IApiRequestLogRepository` em `src/Desbravadores.Gestao.Application/Interfaces/IApiRequestLogRepository.cs` e implementação `ApiRequestLogRepository` em `src/Desbravadores.Gestao.Infrastructure/Repositories/ApiRequestLogRepository.cs` para persistência dos logs no banco.
- Atualiza `AppDbContext` em `src/Desbravadores.Gestao.Infrastructure/Data/AppDbContext.cs` para incluir `DbSet<ApiRequestLog>` e mapeamento EF Core da tabela `ApiRequestLogs` com índices em `DataHora`, `Endpoint`, `StatusCode`, `CorrelationId` e `TraceId`, e registra o repositório no DI em `src/Desbravadores.Gestao.Infrastructure/DependencyInjection.cs` e o middleware no pipeline em `src/Desbravadores.Gestao.Api/Program.cs`.

### Testing
- Foi executada tentativa de build com `dotnet build src/src.sln` mas a execução falhou no ambiente atual devido à ausência do runtime/SDK (`dotnet: command not found`).
- Nenhum teste automatizado foi executado neste ambiente após as alterações por causa da limitação acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb374b816c832ebde97b732c7d348a)